### PR TITLE
Fix issue outscale/osc-cli #10: Make FCU call with GET method

### DIFF
--- a/osc_sdk/sdk.py
+++ b/osc_sdk/sdk.py
@@ -188,7 +188,7 @@ class ApiCall(object):
                                            'x-amz-date:' + self.amz_date,
                                            ''])
             signed_headers = 'host;x-amz-date'
-            payload_hash = hashlib.sha256('').hexdigest()
+            payload_hash = hashlib.sha256(''.encode('utf-8')).hexdigest()
             request_parameters = urllib.parse.urlencode(
                 request_parameters)
             canonical_request = '\n'.join([
@@ -197,6 +197,7 @@ class ApiCall(object):
                 signed_headers, payload_hash])
             request_url = "{}://{}?{}".format(self.protocol, self.host,
                                               request_parameters)
+            request_parameters = None
         else:
             amz_target = '{}_{}.{}'.format(
                 self.SERVICE,


### PR DESCRIPTION
- Logs before the fix
```
$ osc-cli fcu DescribeImages > /dev/null                                                                                                                                                                                                                                                    
DEBUG:urllib3.connectionpool:Starting new HTTPS connection (1): fcu.eu-west-2.outscale.com:443
DEBUG:urllib3.connectionpool:https://fcu.eu-west-2.outscale.com:443 "GET /?Action=DescribeImages&Version=2018-11-19 HTTP/1.1" 403 382
osc_sdk.sdk.OscApiException: Error --> status = 403, code = None, Reason = <?xml version="1.0" encoding="UTF-8"?>
<Response><Errors><Error><Code>SignatureDoesNotMatch</Code><Message>The request signature we calculated does not match the signature you provided. Check your AWS Secret Access Key and signing method. Consult the service documentation for details.</Message></Error></Errors><RequestID>24a6b708-a503-4634-bd0d-11ae4b666192</RequestID></Response>, request_id = None
```
- Logs after the fix:
```
$ osc-cli fcu DescribeImages > /dev/null                                                                                                                                                                                                                                                    
DEBUG:urllib3.connectionpool:Starting new HTTPS connection (1): fcu.eu-west-2.outscale.com:443
DEBUG:urllib3.connectionpool:https://fcu.eu-west-2.outscale.com:443 "GET /?Action=DescribeImages&Version=2018-11-19 HTTP/1.1" 200 37418
```