### PR TITLE
Feature nosysout

### DIFF
--- a/osc_sdk/sdk.py
+++ b/osc_sdk/sdk.py
@@ -244,8 +244,6 @@ class ApiCall(object):
                 headers=headers,
                 verify=SSL_VERIFY))
 
-        print(json.dumps(self.response, indent=4))
-
 
 class FcuCall(ApiCall):
     SERVICE = 'fcu'
@@ -353,8 +351,6 @@ class JsonApiCall(ApiCall):
                 headers=headers,
                 verify=SSL_VERIFY))
 
-        print(json.dumps(self.response, indent=4))
-
 
 class IcuCall(JsonApiCall):
     SERVICE = 'icu'
@@ -427,10 +423,10 @@ def api_connect(service, call, profile='default', *args, **kwargs):
         'okms': OKMSCall,
     }
     conf = get_conf(profile)
-    return calls[service](
-        **conf).make_request(
-            call, *args, **kwargs)
-
+    handler = calls[service](**conf)
+    handler.make_request(call, *args, **kwargs)
+    if handler.response:
+        print(json.dumps(handler.response, indent=4))
 
 def main():
     logging.basicConfig(level=logging.ERROR)


### PR DESCRIPTION
When using as a library to orchestrate HTTP calls through a script, it generates lots of useless outputs. This PR activate sysout prints only when using main function, otherwise when using programmatically (ex: ```client = osc_sdk.FcuCall(**config)```), print function is not used and logs stay clean.