### PR TITLE
[OSCCall] Dirty parsing of value removed

### DIFF
--- a/osc_sdk/sdk.py
+++ b/osc_sdk/sdk.py
@@ -469,9 +469,7 @@ class OSCCall(JsonApiCall):
             parameters.setdefault(head_key, {})
             self.format_data(parameters[head_key], queue_key, value)
         else:
-            parameters[key] = (
-                value[1:-1].split(',') if value.startswith('[') else value
-            )
+            parameters[key] = value
 
 
     def build_url(self, call):


### PR DESCRIPTION
rollback because we can use "['vol-12345678']" format instead.