### PR TITLE
Add client certificate handling

### DIFF
--- a/osc_sdk/sdk.py
+++ b/osc_sdk/sdk.py
@@ -100,7 +100,7 @@ class ApiCall(object):
         self.protocol = 'https' if kwargs.pop('https', None) else 'http'
         self.region = kwargs.pop('region_name', DEFAULT_REGION)
         self.ssl_verify = kwargs.pop('ssl_verify', SSL_VERIFY)
-        self.client_certificate = kwargs.pop('client_certificate')
+        self.client_certificate = kwargs.get('client_certificate')
         endpoint, host = (kwargs.get(x) for x in ['endpoint', 'host'])
         if endpoint:
             self.endpoint = endpoint

--- a/osc_sdk/sdk.py
+++ b/osc_sdk/sdk.py
@@ -100,6 +100,7 @@ class ApiCall(object):
         self.protocol = 'https' if kwargs.pop('https', None) else 'http'
         self.region = kwargs.pop('region_name', DEFAULT_REGION)
         self.ssl_verify = kwargs.pop('ssl_verify', SSL_VERIFY)
+        self.client_certificate = kwargs.pop('client_certificate')
         endpoint, host = (kwargs.get(x) for x in ['endpoint', 'host'])
         if endpoint:
             self.endpoint = endpoint
@@ -275,6 +276,7 @@ class ApiCall(object):
                     headers=headers,
                     method=self.method,
                     url=url,
+                    cert=self.client_certificate,
                     verify=self.ssl_verify))
         )
 
@@ -386,6 +388,7 @@ class JsonApiCall(ApiCall):
                 url=self.get_url(call),
                 data=json_params,
                 headers=headers,
+                cert=self.client_certificate,
                 verify=self.ssl_verify,
             )
         )

--- a/osc_sdk/sdk.py
+++ b/osc_sdk/sdk.py
@@ -269,15 +269,15 @@ class ApiCall(object):
             'User-agent': USER_AGENT,
         })
 
-        self.response = (
-            self.get_response(
-                requests.request(
-                    data=request_params,
-                    headers=headers,
-                    method=self.method,
-                    url=url,
-                    cert=self.client_certificate,
-                    verify=self.ssl_verify))
+        self.response = self.get_response(
+            requests.request(
+                cert=self.client_certificate,
+                data=request_params,
+                headers=headers,
+                method=self.method,
+                url=url,
+                verify=self.ssl_verify
+            )
         )
 
 
@@ -384,11 +384,11 @@ class JsonApiCall(ApiCall):
 
         self.response = self.get_response(
             requests.request(
-                method=self.method,
-                url=self.get_url(call),
+                cert=self.client_certificate,
                 data=json_params,
                 headers=headers,
-                cert=self.client_certificate,
+                method=self.method,
+                url=self.get_url(call),
                 verify=self.ssl_verify,
             )
         )


### PR DESCRIPTION
A new key can be used in configuration file: "client_certificate".
This key is a raw mapping for `requests.request` `cert` parameter
(https://2.python-requests.org/en/master/api/#requests.Session.cert) and
its value is used as is.