### PR TITLE
osc_sdk/sdk.py: Change api_connect() output format

### DIFF
--- a/osc_sdk/sdk.py
+++ b/osc_sdk/sdk.py
@@ -538,7 +538,7 @@ def api_connect(service, call, profile='default', *args, **kwargs):
     handler = calls[service](**conf)
     handler.make_request(call, *args, **kwargs)
     if handler.response:
-        print(json.dumps(handler.response, indent=4))
+        return handler.response
 
 
 def main():


### PR DESCRIPTION
    When called, api_connect was printing result to stdout.

    Now return "handler.response" "as is" which let the caller
    choose if he/she wants to print, or do something else