### PR TITLE
Error with bool parameters fixed

### DIFF
--- a/osc_sdk/sdk.py
+++ b/osc_sdk/sdk.py
@@ -494,7 +494,11 @@ class OSCCall(JsonApiCall):
             parameters.setdefault(head_key, {})
             self.format_data(parameters[head_key], queue_key, value)
         else:
-            parameters[key] = value
+            parameters[key] = (
+                value[1:-1].split(',')
+                if not isinstance(value, bool) and value.startswith('[')
+                else value
+            )
 
     def get_canonical_uri(self, call):
         return '/{}/latest/{}'.format(self.API_NAME, call)

--- a/osc_sdk/sdk.py
+++ b/osc_sdk/sdk.py
@@ -496,7 +496,7 @@ class OSCCall(JsonApiCall):
         else:
             parameters[key] = (
                 value[1:-1].split(',')
-                if not isinstance(value, bool) and value.startswith('[')
+                if isinstance(value, str) and value.startswith('[')
                 else value
             )
 


### PR DESCRIPTION
Si on a un paramètre qui contient un booléan (par exemple avec le call CreateCa), la gestion des paramètres va raised une erreur car `value.startswith` n'aime pas les booléans :   
```
File "/Users/francois.rabanel/DEV/osc-cli/osc_sdk/sdk.py", line 475, in format_data
   value[1:-1].split(',') if value.startswith('[') else value 
AttributeError: 'bool' object has no attribute 'startswith'  
```