### PR TITLE
add linux packaging

### DIFF
--- a/pkg/Makefile
+++ b/pkg/Makefile
@@ -1,0 +1,50 @@
+# either 1, 2010 or 2014
+WHICH_LINUX=2010
+
+# go https://github.com/niess/python-appimage/releases for the list
+PY_MAJ=3
+PY_MID=9
+PY_MIN=6
+PY_VER=$(PY_MAJ).$(PY_MID)
+PY_CP=cp$(PY_MAJ)$(PY_MID)
+PY_STR=python$(PY_VER)
+PY_TARGET="$(PY_STR).$(PY_MIN)-$(PY_CP)-$(PY_CP)-manylinux$(WHICH_LINUX)_x86_64.AppImage"
+
+all: osc-cli-x86_64.AppImage
+
+$(PY_TARGET):
+	wget https://github.com/niess/python-appimage/releases/download/$(PY_STR)/$(PY_TARGET)
+	chmod +x ./$(PY_TARGET)
+
+osc-cli.AppDir/: $(PY_TARGET)
+	./$(PY_TARGET) --appimage-extract
+	mv squashfs-root osc-cli.AppDir
+
+osc-cli.AppDir/AppRun-py: osc-cli.AppDir/ $(PY_TARGET)
+	cp osc-cli.AppDir/AppRun osc-cli.AppDir/AppRun-py
+
+osc-cli.AppDir/AppRun: osc-cli.AppDir/ $(PY_TARGET) osc-cli.AppDir/AppRun-py
+	cp linux/AppRun osc-cli.AppDir/
+
+osc-cli.AppDir/done:
+	cd .. && pkg/osc-cli.AppDir/AppRun-py ./setup.py install --prefix=./pkg/osc-cli.AppDir/opt/$(PY_STR)/ --optimize=1
+	cd osc-cli.AppDir/ && \
+	for package in requests charset-normalizer urllib3 defusedxml fire xmltodict termcolor idna ; do  \
+	PIP_CONFIG_FILE=/dev/null usr/bin/pip$(PY_VER) install --isolated --root="" --ignore-installed --no-deps $${package} \
+	; done
+	rm osc-cli.AppDir/$(PY_STR).$(PY_MIN).desktop
+	cp linux/osc-cli.desktop osc-cli.AppDir/
+	echo 'export PY_VERSION=$(PY_VER)' > osc-cli.AppDir/py_version.sh
+	echo 'export PY_STR=$(PY_STR)' >> osc-cli.AppDir/py_version.sh
+	touch osc-cli.AppDir/done
+
+
+appimagetool-x86_64.AppImage:
+	wget https://github.com/AppImage/AppImageKit/releases/download/13/appimagetool-x86_64.AppImage
+	chmod +x appimagetool-x86_64.AppImage
+
+osc-cli-x86_64.AppImage: osc-cli.AppDir/AppRun osc-cli.AppDir osc-cli.AppDir/done appimagetool-x86_64.AppImage $(PY_TARGET)
+	./appimagetool-x86_64.AppImage osc-cli.AppDir/
+
+clean:
+	rm -rvf *AppImage* osc-cli.AppDir

--- a/pkg/README.md
+++ b/pkg/README.md
@@ -1,0 +1,21 @@
+# osc-cli packages maker
+
+This directory contain methods to create osc-cli packages
+
+## Make All
+
+just type `make`
+
+this will create all packages, for now only AppImage is supported
+
+## Linux Appimage
+
+```
+make osc-cli-x86_64.AppImage
+```
+
+## clean
+
+```
+make clean
+```

--- a/pkg/linux/AppRun
+++ b/pkg/linux/AppRun
@@ -1,0 +1,21 @@
+#! /bin/bash
+
+source "${APPDIR}/py_version.sh"
+# Export APPRUN if running from an extracted image
+self="$(readlink -f -- $0)"
+here="${self%/*}"
+APPDIR="${APPDIR:-${here}}"
+
+# Export TCl/Tk
+export TCL_LIBRARY="${APPDIR}/usr/share/tcltk/tcl8.5"
+export TK_LIBRARY="${APPDIR}/usr/share/tcltk/tk8.5"
+export TKPATH="${TK_LIBRARY}"
+
+# Export SSL certificate
+export SSL_CERT_FILE="${APPDIR}/opt/_internal/certs.pem"
+
+export LC_ALL=C
+
+# Call the entry point
+#! /bin/bash
+${APPDIR}/usr/bin/${PY_STR} "${APPDIR}/opt/${PY_STR}/bin/osc-cli" "$@"

--- a/pkg/linux/osc-cli.desktop
+++ b/pkg/linux/osc-cli.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Type=Application
+Name=osc-cli
+Exec=osc-cli
+Comment=Outscale Cli
+Icon=python
+Categories=Development;
+Terminal=true


### PR DESCRIPTION
This add a pkg directory that contain a Makefile used to create an AppImage of osc-cli (here based on python 3.10.0).

note that: the makefile require appimagetool as dependency (findable here: https://github.com/AppImage/AppImageKit/tags) and is based on https://github.com/niess/python-appimage repository

I could download appimagetool in the Makefile too, if that suite you better ?

Also because I'm based on niess python-appimage repo, the Makefile need to stay updated, as niess seems to remove old python build.

Signed-off-by: Matthias Gatto <matthias.gatto@outscale.com>