### PR TITLE
New conf  management

### DIFF
--- a/osc_sdk/sdk.py
+++ b/osc_sdk/sdk.py
@@ -30,6 +30,9 @@ DEFAULT_PROFILE = "default"
 DEFAULT_REGION = "eu-west-2"
 DEFAULT_VERSION = datetime.date.today().strftime("%Y-%m-%d")
 DEFAULT_AUTHENTICATION_METHOD = "accesskey"
+
+DEFAULT_HOST = "outscale.com"
+
 METHODS_SUPPORTED = {"GET", "POST"}
 SDK_VERSION = "1.7.1"
 SSL_VERIFY = True
@@ -655,6 +658,12 @@ def get_conf(profile: str) -> Configuration:
         json_profile = json_profiles[v]
         if "region" in json_profile:
 
+            # use default stuffs only when "region" is use
+            # to keep region_name format retrocompatible
+            if not "host" in json_profile and not "endpoint" in json_profile:
+                json_profile["host"] = DEFAULT_HOST
+            if not "https" in json_profile:
+                json_profile["https"] = True
 
             if not "region_name" in json_profile:
                 json_profile["region_name"] = json_profile["region"]

--- a/osc_sdk/sdk.py
+++ b/osc_sdk/sdk.py
@@ -649,7 +649,17 @@ def get_conf(profile: str) -> Configuration:
     if not conf_path:
         raise RuntimeError("No configuration file found in home folder")
 
-    conf = cast(Mapping[str, Configuration], json.loads(conf_path.read_text()))
+    json_profiles = json.loads(conf_path.read_text())
+    # convert region to region_name in json to fit Mapping
+    for v in json_profiles:
+        json_profile = json_profiles[v]
+        if "region" in json_profile:
+
+
+            if not "region_name" in json_profile:
+                json_profile["region_name"] = json_profile["region"]
+            del json_profile["region"]
+    conf = cast(Mapping[str, Configuration], json_profiles)
     try:
         return conf[profile]
     except KeyError:


### PR DESCRIPTION
* fix #153
* Add default for `host` and `https` if `region` is found in config (the rational is that http was the default, so making it default everywhere could break some conf)