### PR TITLE
Add ReadPublicCatalog call to non authenticated calls

### DIFF
--- a/osc_sdk/sdk.py
+++ b/osc_sdk/sdk.py
@@ -56,6 +56,7 @@ NO_AUTH_CALLS: Dict[str, Set[str]] = {
         "ReadVmTypes",
         "ResetAccountPassword",
         "SendResetPasswordEmail",
+        "ReadPublicCatalog",
     },
     "icu": {
         "AuthenticateAccount",


### PR DESCRIPTION
With Outscale API 1.19.0, a new non-authenticated call ReadPublicCatalog is available.

See https://docs.outscale.com/fr/userguide/Notes-de-releases-API.html

closes #183
