### PR TITLE
fix pyinstaller-windows, using Msys2 

### DIFF
--- a/.github/workflows/Pyinstaller-windows.yml
+++ b/.github/workflows/Pyinstaller-windows.yml
@@ -1,0 +1,51 @@
+name: Package Application with Pyinstaller on Mingw64
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: msys2/setup-msys2@v2
+      with:
+        msystem: MINGW64
+        install: >-
+          git
+          base-devel
+          zip
+        pacboy:
+          openssl
+          python-pip
+
+    - shell: msys2 {0}
+      run: |
+        git submodule update --init
+        python --version
+        python -m pip install pyinstaller
+        python -m pip install .
+        pyinstaller --distpath ./pkg --clean --name osc-cli osc_sdk/sdk.py --add-data /mingw64/bin/libcrypto-1_1-x64.dll:. --add-data /mingw64/bin/libssl-1_1-x64.dll:.
+        zip -r osc-cli-x86_64.zip pkg/osc-cli
+        ./pkg/osc-cli/osc-cli.exe api ReadRegions | grep api.eu-west-2.outscale.com
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v2
+      if: ${{ github.event_name != 'push' }}
+      with:
+        name: osc-cli-win
+        path: |
+          osc-cli-x86_64.zip
+    - name: upload nightly
+      uses: "marvinpinto/action-automatic-releases@latest"
+      if: ${{ github.event_name == 'push' }}
+      with:
+        repo_token: "${{ secrets.GITHUB_TOKEN }}"
+        prerelease: true
+        automatic_release_tag: "nightly-windows"
+        title: "Windows Development Build"
+        files: |
+          osc-cli-x86_64.zip

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -21,8 +21,6 @@ jobs:
       run: |
         cd pkg && make osc-cli-x86_64.AppImage
         ./osc-cli-x86_64.AppImage 2>&1 | grep Usage
-    - name: Package for Windows
-      run: cd pkg && make osc-cli-x86_64.zip
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
@@ -31,7 +29,6 @@ jobs:
           dist/osc_sdk-*.whl
           dist/osc-sdk-*.tar.gz
           pkg/osc-cli-x86_64.AppImage
-          pkg/osc-cli-x86_64.zip
   tests-python-3-6:
     runs-on: ubuntu-latest
     steps:

--- a/pkg/Makefile
+++ b/pkg/Makefile
@@ -37,12 +37,6 @@ appimagetool-x86_64.AppImage:
 osc-cli-x86_64.AppImage:  osc-cli.AppDir/done appimagetool-x86_64.AppImage
 	./appimagetool-x86_64.AppImage osc-cli.AppDir/
 
-osc-cli-x86_64.zip: osc-cli
-	zip -r osc-cli-x86_64.zip osc-cli
-
-osc-cli:
-	$(SUDO) docker run --rm -v ${PWD}/..:/src outscale/wine-pyinstaller:0.0.1 --distpath ./pkg --clean --name osc-cli osc_sdk/sdk.py
-
 osc-api.json:
 	curl -s https://raw.githubusercontent.com/outscale/osc-api/master/outscale.yaml | yq $(YQ_ARG) > osc-api.json
 
@@ -74,7 +68,7 @@ osc-cli-completion.bash: osc-api.json osc-cli-completion.call_list osc-cli-compl
 
 clean:
 	rm -rvf appimagetool-x86_64.AppImage osc-cli-x86_64.AppImage python*AppImage\
-		osc-cli.AppDir osc-cli.zip osc-cli osc-cli-completion.bash\
+		osc-cli.AppDir  osc-cli-completion.bash\
 		osc-cli-completion.call_list \
 		osc-cli-completion.calls osc-api.json config.sh
 


### PR DESCRIPTION
    .github: add pyinstaller-windows

    As the Makefile use a docker that use wine that use pyinstaller, is currently
    broken, and is hard to debug, this new workflow, use windows directly
    with Msys 2 (which use the glorious Pacman from I use Arch BTW).

    I've also remove the old windwos build from the pull-request workflow,
    and add a warning in the makefile to notice user that the rule is curently
    broken.

    See you wine build, someday somewhere!

    fix #190